### PR TITLE
Improve command line help to use a more common file extension.

### DIFF
--- a/include/command_line/command_line_config.h
+++ b/include/command_line/command_line_config.h
@@ -40,11 +40,11 @@ class CommandLineConfig {
     auto& debug = FlagArg::create("debug_args")
                   .description("Print program arguments and quit");
     auto& read_config = ValueArg<std::string>::create("config")
-                        .usage("<path/to/file.dat>")
+                        .usage("<path/to/file.conf>")
                         .default_val("")
                         .description("Read program args from a configuration file");
     auto& write_config = ValueArg<std::string>::create("example_config")
-                         .usage("<path/to/file.dat>")
+                         .usage("<path/to/file.conf>")
                          .default_val("")
                          .description("Print an example configuration file");
 


### PR DESCRIPTION
Just like with my recent changes to stoke, this would help the zsh completion, and it seems (at least in stoke), we exclusively use the file extension conf.
